### PR TITLE
Don't allow concurrent builds for same branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Improve GitHub Actions workflow with this:

1. auto-cancel concurrent jobs if the subsequent commit is detected in a branch, where the build hasn't finished yet
